### PR TITLE
Update .travis.yml so redirection for links work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ deploy:
     secret_access_key: $AWS_SECRET_ACCESS_KEY
     skip_cleanup: true
     local_dir: website/build/safe-docs
-    upload-dir: current/safe
+    upload-dir: safe
     on:
       branch: master
       node: '12'


### PR DESCRIPTION
Links without trailing slash (/) need for a redirect to the link with trailing slash in AWS Cloudfront + S3 setup. By using the protocol folder directly instead of a proxy folder called current, this redirections work as expected