### PR TITLE
Add known projects integrating with the Safe.

### DIFF
--- a/docs/intro_08_projects.md
+++ b/docs/intro_08_projects.md
@@ -1,0 +1,35 @@
+---
+id: intro_projects
+title: Projects building with the Gnosis Safe
+sidebar_label: External projects
+---
+
+This is an incomplete and unordered list of projects build on or integrating with the Gnosis Safe. This includes projects leveraging the contracts, backend infrastructure as well as parts of the Gnosis Safe interfaces, including [Safe apps](sdks_03_safe_apps.md).
+
+- [1inch](https://1inch.exchange/): Safe apps
+- [Aave](https://aave.com/): Safe apps
+- [Balancer](https://balancer.finance/): Safe apps, Gnosis Safe Multisig
+- [Burner wallet](https://xdai.io/): Smart contract accounts
+- [DIAdata](https://diadata.org/): Gnosis Safe Multisig
+- [ENS](https://ens.domains): Gnosis Safe Multisig
+- [Ethhub](https://ethhub.io/): Gnosis Safe Multisig
+- [Gelato](https://gelato.finance/): Smart contract accounts
+- [Groundhog](https://groundhog.network/): Contract module
+- [Metamask](https://metamask.io/): Smart contract accounts
+- [Open Zeppelin](https://openzeppelin.com/): Safe apps
+- [Omen](omen.eth.link/): Contract proxy kit
+- [Request network](https://request.network): Safe apps
+- [Sablier](https://sablier.finance/): Safe apps
+- [Slock it](https://slock.it/): Smart contract accounts
+- [Synthetix](https://synthetix.io/): Safe apps
+- [Tasit](https://tasit.io/): Smart contract accounts
+- [Unilogin](https://unilogin.io/): Smart contract accounts
+- [Yearn](https://yearn.finance/): Gnosis Safe Multisig
+
+Hackathon projects:
+- https://devpost.com/software/hermes-network
+- https://devpost.com/software/mapcovery
+- https://devpost.com/software/multy
+- https://devpost.com/software/peerduck
+
+If you know of any projects missing on this list, [please let us know](https://discordapp.com/invite/FPMRAwK).

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -159,11 +159,11 @@ class HomeSplash extends React.Component {
           <div>
            <a name="projects">
             <h2>
-              Projects building on <br></br> the Gnosis Safe contracts
+              Projects building with <br></br>the Gnosis Safe
             </h2>
             </a>
             <p>
-              The Gnosis Safe smart contracts are already used by those projects.
+              The Gnosis Safe is used or integrated with those projects.
             </p>
           </div>
 
@@ -174,9 +174,6 @@ class HomeSplash extends React.Component {
             <a href="https://burnerwallet.co/" className="white-box">
               <img className="index-projects-img" src={`${baseUrl}img/burner.png`}></img>
             </a>
-           <a href="https://pepo.com/" className="white-box">
-            <img className="index-projects-img" src={`${baseUrl}img/peposq.png`}></img>
-            </a>
             <a href="https://unilogin.io/" className="white-box">
               <img className="index-projects-img" src={`${baseUrl}img/universalloging.png`}></img>
             </a>
@@ -186,6 +183,17 @@ class HomeSplash extends React.Component {
             <a href="https://tasit.io/" className="white-box">
               <img className="index-projects-img" src={`${baseUrl}img/tasit.png`}></img>
             </a>
+            
+            <a href={docUrl("intro_projects")} className="white-box">
+                <h3>
+                    More projects
+                </h3>
+                <p>
+                    List of projects building with the Gnosis Safe.
+                </p>
+            </a>
+
+
           </div>
         </div>
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -7,7 +7,8 @@
       "intro_interfaces",
       "intro_statistics",
       "intro_audits",
-      "intro_bug_bounty"
+      "intro_bug_bounty",
+      "intro_projects"
     ]
   },
   "contracts": {


### PR DESCRIPTION
This is to deprecate https://gist.github.com/tschubotz/03e4f6870403857d0d870a23da12680f/revisions and make people aware of other projects building on top of the Safe.