### PR TITLE
Fix/tutorial links

### DIFF
--- a/docs/services_04_tutorials.md
+++ b/docs/services_04_tutorials.md
@@ -4,58 +4,14 @@ title: Tutorials
 sidebar_label: Tutorials
 ---
 
-<div class="inner grid-blocks two-blocks-grid tutorials-boxes">
-    <div onclick="location.href='https://github.com/gnosis/safe-demo';" class="white-box" style="cursor:pointer">
-        <h3>
-            Interact with the Relay service
-        </h3>
-        <p>
-            How to estimate and submit a transactions via the Relay service
-        </p>
-        <p class="box-icons">
-            <i class="icon icon-small icon-time"></i>
-            &nbsp;
-            30min
-            &nbsp;
-            &nbsp;
-            <i class="icon icon-small icon-star"></i>
-            &nbsp;
-            medium
-            &nbsp;
-            &nbsp;
-            <i class="icon icon-small icon-pen"></i>
-            JS
-        </p>
-    </div>
-    <div onclick="location.href='./txservicetutorial1'" class="white-box" style="cursor:pointer">       
-        <h3>
-            Interact with the transaction service
-        </h3>
-        <p>
-            Propose a transaction to the transaction service
-        </p>
-        <p className="box-icons">
-            <i className="icon icon-small icon-time"></i>
-            &nbsp;
-            30min
-            &nbsp;
-            &nbsp;
-            <i className="icon icon-small icon-star"></i>
-            &nbsp;
-            medium
-            &nbsp;
-            &nbsp;
-            <i className="icon icon-small icon-pen"></i>
-            JS
-        </p>
-    </div>
-    <div onclick="location.href='../../tutorials';" class="white-box" style="cursor:pointer">
-        <h3>
-            More tutorials
-        </h3>
-        <p>
-            Check out our other tutorials for the Gnosis Safe.
-        </p>
-    </div>
-</div>
+## Interact with the Relay service
 
+- [How to estimate and submit a transactions via the Relay service](https://github.com/gnosis/safe-demo)
+
+## Interact with the Transcation service
+
+- [Propose a transaction to the transaction service](txservicetutorial1)
+    
+## More tutorials
+        
+Check out our [other tutorials](tutorials) for the Gnosis Safe.

--- a/docs/services_04_tutorials.md
+++ b/docs/services_04_tutorials.md
@@ -4,14 +4,58 @@ title: Tutorials
 sidebar_label: Tutorials
 ---
 
-## Interact with the Relay service
+<div class="inner grid-blocks two-blocks-grid tutorials-boxes">
+    <div onclick="location.href='https://github.com/gnosis/safe-demo';" class="white-box" style="cursor:pointer">
+        <h3>
+            Interact with the Relay service
+        </h3>
+        <p>
+            How to estimate and submit a transactions via the Relay service
+        </p>
+        <p class="box-icons">
+            <i class="icon icon-small icon-time"></i>
+            &nbsp;
+            30min
+            &nbsp;
+            &nbsp;
+            <i class="icon icon-small icon-star"></i>
+            &nbsp;
+            medium
+            &nbsp;
+            &nbsp;
+            <i class="icon icon-small icon-pen"></i>
+            JS
+        </p>
+    </div>
+    <div onclick="location.href='../txservicetutorial1';" class="white-box" style="cursor:pointer">
+        <h3>
+            Interact with the Transaction service
+        </h3>
+        <p>
+            How to propose a transactions to the Transaction service
+        </p>
+        <p class="box-icons">
+            <i class="icon icon-small icon-time"></i>
+            &nbsp;
+            30min
+            &nbsp;
+            &nbsp;
+            <i class="icon icon-small icon-star"></i>
+            &nbsp;
+            medium
+            &nbsp;
+            &nbsp;
+            <i class="icon icon-small icon-pen"></i>
+            JS
+        </p>
+    </div>
+    <div onclick="location.href='../../tutorials';" class="white-box" style="cursor:pointer">
+        <h3>
+            More tutorials
+        </h3>
+        <p>
+            Check out our other tutorials for the Gnosis Safe.
+        </p>
+    </div>
+</div>
 
-- [How to estimate and submit a transactions via the Relay service](https://github.com/gnosis/safe-demo)
-
-## Interact with the Transaction service
-
-- [Propose a transaction to the Transaction service](txservicetutorial1)
-    
-## More tutorials
-        
-Check out our [other tutorials](tutorials) for the Gnosis Safe.

--- a/docs/services_04_tutorials.md
+++ b/docs/services_04_tutorials.md
@@ -8,9 +8,9 @@ sidebar_label: Tutorials
 
 - [How to estimate and submit a transactions via the Relay service](https://github.com/gnosis/safe-demo)
 
-## Interact with the Transcation service
+## Interact with the Transaction service
 
-- [Propose a transaction to the transaction service](txservicetutorial1)
+- [Propose a transaction to the Transaction service](txservicetutorial1)
     
 ## More tutorials
         


### PR DESCRIPTION
Getting rid of these tutorial cards in markdown since link become not maintainable in this structure.