### PR TITLE
Changing EthCC3 talk link to contain timecode

### DIFF
--- a/docs/sdks_03_safe_apps.md
+++ b/docs/sdks_03_safe_apps.md
@@ -8,7 +8,7 @@ sidebar_label: Safe Apps
 
 With over $1B worth of digital assets held in Gnosis Multisigs alone, it’s essential for the dapp ecosystem to access the untapped market of multi-signature wallets. Safe Apps introduce a completely new way for developers to build their dapps right into a Multisig interface. Turn your Dapp into an HTML iframe component that can be accessed through the Safe Multisig. We are providing extensive developer tooling to make it easy to develop, test and integrate Safe Apps into the Safe Multisig. This includes a unique design system, reusable components and a Safe App SDK that facilitates the Safe App <> Safe Multisig communication.
 
-Please refer to this [EthCC3 talk](https://www.youtube.com/watch?v=1GirpNHZPJM) to learn more about Safe Apps.
+Please refer to this [EthCC3 talk](https://www.youtube.com/watch?v=1GirpNHZPJM&t=168s) to learn more about Safe Apps.
 
 There are already Safe Apps available for a number of popular protocols such as [Aave](https://aave.com/), [Synthetix](https://synthetix.io/), [1inch](https://1inch.exchange/) or [Balancer](https://balancer.finance/). These have been build by 3rd party developers or the projects themselves.
 


### PR DESCRIPTION
YouTube link should include time code because the talk starts almost 3 minutes in.