### PR TITLE
docs: add sync EIP-1271

### DIFF
--- a/learn/safe-core/safe-core-protocol/signatures/eip-1271.md
+++ b/learn/safe-core/safe-core-protocol/signatures/eip-1271.md
@@ -8,6 +8,11 @@ This doc explains signing and verifying messages off-chain. All examples use [Wa
 
 It is possible to sign [EIP-191](https://eips.ethereum.org/EIPS/eip-191) compliant messages as well as [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data messages.
 
+### Restrictions
+
+- Only Safe contracts of version `>=1.1.0` are supported.
+- Signing off-chain messages with smart contract wallets is not yet supported.
+
 ### Enabling off-chain signing
 
 Multiple dApps rely on on-chain signing.
@@ -225,8 +230,3 @@ If your signing requests fallback to on-chain signing this could be because of m
 
 - `message` or `messageHash` is used to verify or sign messages.
 - `safeMessageHash` is used to fetch data from the `safe-transaction-service`.
-
-## Restrictions
-
-- Only Safe contracts of version `>=1.1.0` are supported.
-- Signing off-chain messages with smart contract wallets is not yet supported.


### PR DESCRIPTION
This updates the current documentation about off-chain signatures to include the forthcoming synhronous flow.