### PR TITLE
chore: pin GitHub actions and add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+version: 2
+
+updates:
+  # Keep GitHub Actions up to date (maintains SHA pins + version comments)
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 10
+
+  # Keep npm/pnpm dependencies up to date
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 10
+    # Align with pnpm-workspace.yaml minimumReleaseAge (10080 minutes = 7 days)
+    cooldown:
+      default-days: 7
+    groups:
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+        update-types:
+          - 'minor'
+          - 'patch'
+      mui:
+        patterns:
+          - '@mui/*'
+          - '@emotion/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      next:
+        patterns:
+          - 'next'
+          - '@next/*'
+          - 'eslint-config-next'
+        update-types:
+          - 'minor'
+          - 'patch'
+      eslint:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@typescript-eslint/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      typescript-toolchain:
+        patterns:
+          - 'typescript'
+          - 'ts-node'
+          - '@types/*'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 #v2.2.2
         with:
           app-id: ${{ secrets.MODULE_ACCESS_APP_ID }}
           private-key: ${{ secrets.MODULE_ACCESS_PRIVATE_KEY }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,7 +56,7 @@ jobs:
           private-key: ${{ secrets.MODULE_ACCESS_PRIVATE_KEY }}
           owner: safe-global
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -18,9 +18,9 @@ jobs:
     name: Deploy release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
 
       - name: Install dependencies
         shell: bash
@@ -38,7 +38,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=8000'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -49,7 +49,7 @@ jobs:
         run: bash ./.github/scripts/s3_upload.sh
 
       - name: Configure production AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           role-to-assume: ${{ secrets.AWS_PRODUCTION_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,9 +29,9 @@ jobs:
             ⏳ Deploying a preview site...
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
 
       - uses: actions/cache@v4
         with:
@@ -63,7 +63,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=8000'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,13 +21,20 @@ jobs:
       # Post a PR comment before deploying
       - name: Post a comment while building
         if: github.event.number
-        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc  # v2.8.2
-        with:
-          message-id: praul
-          message: |
-            ## Branch preview
-            ⏳ Deploying a preview site...
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MARKER="<!-- deploy-preview-praul -->"
+          BODY="${MARKER}
+          ## Branch preview
+          ⏳ Deploying a preview site..."
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.number }}/comments" \
+            --paginate --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" -X PATCH -f body="$BODY"
+          else
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.number }}/comments" -f body="$BODY"
+          fi
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -86,17 +93,28 @@ jobs:
         run: bash ./.github/scripts/s3_upload.sh
 
       # Comment with the deployment link
-      - name: Post an epic deployment link in the PR
+      - name: Post a deployment link in the PR
         if: always() && github.event.number
-        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc  # v2.8.2
-        with:
-          message-id: praul
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          message: |
-            ## Branch preview
-            ✅ Deployed successfully in branch deployment:
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MARKER="<!-- deploy-preview-praul -->"
+          if [ "${{ job.status }}" = "success" ]; then
+            BODY="${MARKER}
+          ## Branch preview
+          ✅  Deploy successful!
 
-            https://${{ steps.extract_branch.outputs.branch }}--docs.review.5afe.dev
-          message-failure: |
-            ## Branch preview
-            ❌ Deploy failed!
+          **Website:**
+          https://${{ steps.extract_branch.outputs.branch }}--docs.review.5afe.dev"
+          else
+            BODY="${MARKER}
+          ## Branch preview
+          ❌  Deploy failed!"
+          fi
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.number }}/comments" \
+            --paginate --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" -X PATCH -f body="$BODY"
+          else
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.number }}/comments" -f body="$BODY"
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       # Post a PR comment before deploying
       - name: Post a comment while building
         if: github.event.number
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc  # v2.8.2
         with:
           message-id: praul
           message: |
@@ -33,16 +33,19 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
 
-      - uses: actions/cache@v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          path: |
-            ~/.npm
-            ${{ github.workspace }}/.next/cache
+          node-version: 22
+          cache: 'pnpm'
+
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
           # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
       
       # Extract branch name
       - name: Extract branch name
@@ -85,7 +88,7 @@ jobs:
       # Comment with the deployment link
       - name: Post an epic deployment link in the PR
         if: always() && github.event.number
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc  # v2.8.2
         with:
           message-id: praul
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-supported-networks.yml
+++ b/.github/workflows/generate-supported-networks.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   generate-supported-networks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -21,4 +24,4 @@ jobs:
         run: pnpm generate-supported-networks
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5  # v5.0.3

--- a/.github/workflows/generate-supported-networks.yml
+++ b/.github/workflows/generate-supported-networks.yml
@@ -9,9 +9,9 @@ jobs:
   generate-supported-networks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/generate-supported-networks.yml
+++ b/.github/workflows/generate-supported-networks.yml
@@ -24,4 +24,26 @@ jobs:
         run: pnpm generate-supported-networks
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5  # v5.0.3
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes detected, skipping PR creation"
+            exit 0
+          fi
+
+          BRANCH="auto/update-supported-networks"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add .
+          git commit -m "chore: update supported networks"
+          git push origin "$BRANCH" --force
+
+          gh pr create \
+            --title "chore: update supported networks" \
+            --body "Automated weekly update of supported networks." \
+            --base main \
+            --head "$BRANCH" \
+          2>/dev/null || echo "PR already exists for branch $BRANCH, branch updated."

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -9,7 +9,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: tcort/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -8,9 +8,11 @@ on:
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: tcort/github-action-markdown-link-check@v1
+    - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225  # v1.1.2
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/report-readability.yml
+++ b/.github/workflows/report-readability.yml
@@ -6,12 +6,15 @@ jobs:
     report-readability:
         name: Report readability
         runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          pull-requests: write
         steps:
             - name: Checkout repo with history
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
               with:
                   fetch-depth: 0
-            - uses: Rebilly/lexi@v2
+            - uses: Rebilly/lexi@5a517542b048ca8cb46e43f27736fed84dfb0e84  # v2.3.6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   glob: '**/*.{md,mdx}'

--- a/.github/workflows/report-readability.yml
+++ b/.github/workflows/report-readability.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repo with history
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
               with:
                   fetch-depth: 0
             - uses: Rebilly/lexi@v2

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -1,4 +1,5 @@
 name: Style check
+
 on: pull_request
 
 jobs:
@@ -14,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Vale Linter
-        uses: vale-cli/vale-action@v2.1.1
+        uses: vale-cli/vale-action@d89dee975228ae261d22c15adcd03578634d429c  # v2.1.1
         with:
           vale_flags: "--glob=pages/**/*.{md,mdx} --minAlertLevel=error"
           fail_on_error: true

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -9,7 +9,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/weekly-link-check.yml
+++ b/.github/workflows/weekly-link-check.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: tcort/github-action-markdown-link-check@v1
+    - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225  # v1.1.2
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/weekly-link-check.yml
+++ b/.github/workflows/weekly-link-check.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       issues: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: tcort/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
-settings:
-  minimumReleaseAge: '10080' # 7 days in minutes
+minimumReleaseAge: 10080 # 7 days in minutes
+onlyBuiltDependencies: []
+blockExoticSubdeps: true


### PR DESCRIPTION
## What it solves

Pins Github actions using SHA. Aligns dependabot policy.

## Changelog

- Ensures correct pnpm-workspace
- Pins Github actions using SHA
- Limit actions permissions
- Aligns dependebot policy 

## Checklist

- [ ] I've followed all `safe-docs` [pull request rules](https://safe-global.notion.site/safe-docs-pr-rules)