### PR TITLE
fix: update transaction-builder help link in unattended-commands

### DIFF
--- a/pages/advanced/cli-reference/unattended-commands.mdx
+++ b/pages/advanced/cli-reference/unattended-commands.mdx
@@ -115,7 +115,7 @@ safe-cli send-erc721 [OPTIONS] SAFE_ADDRESS NODE_URL TO TOKEN_ADDRESS TOKEN_ID
 
 Execute a transaction or transaction batch from a `JSON` file. The format of the file is the same as the one used from the [Safe\{Wallet}](https://app.safe.global) website in the `Transaction Builder` application.
 
-This [guide](https://help.safe.global/en/articles/234052-transaction-builder) explains how to use the tx-builder application.
+This [guide](https://help.safe.global/articles/4180673514-transaction-builder?lang=en) explains how to use the tx-builder application.
 
 ```bash
 safe-cli tx-builder [OPTIONS] SAFE_ADDRESS NODE_URL FILE_PATH


### PR DESCRIPTION
## Summary
- Replace the outdated `help.safe.global/en/articles/234052-transaction-builder` link on the `/advanced/cli-reference/unattended-commands` page with the current `https://help.safe.global/articles/4180673514-transaction-builder?lang=en` URL.

## Test plan
- [ ] Visit `/advanced/cli-reference/unattended-commands` and verify the "guide" link resolves to the live Transaction Builder help article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)